### PR TITLE
Potential fix for code scanning alert no. 3: Expression injection in Actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -58,14 +58,13 @@ jobs:
       #    We’ll transform multiline release notes to a single line, so shell won't break.
       #    Then pass them to docker build via --label.
       - name: Build Docker Image
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          # 1) Grab the commit message from the GitHub event
-          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
-      
-          # 2) (Optional) Flatten or sanitize if it can contain newlines/quotes:
+          # 1) Flatten or sanitize if it can contain newlines/quotes:
           CLEAN_MSG=$(echo "$COMMIT_MESSAGE" | tr '\n' ' ' | sed 's/"/\\"/g')
       
-          # 3) Use CLEAN_MSG in your Docker build label
+          # 2) Use CLEAN_MSG in your Docker build label
           docker build \
             -t ghcr.io/${{ github.repository }}/my-christmas-app:${{ github.ref_name }} \
             -t ghcr.io/${{ github.repository }}/my-christmas-app:latest \


### PR DESCRIPTION
Potential fix for [https://github.com/markcoleman/christmas-fun-2024/security/code-scanning/3](https://github.com/markcoleman/christmas-fun-2024/security/code-scanning/3)

To fix the problem, we should avoid using the user-controlled input directly in the shell command. Instead, we can set the untrusted input value to an intermediate environment variable and then use the environment variable using the native syntax of the shell. This approach ensures that the input is handled safely by the shell.

- Set the commit message to an environment variable.
- Use the environment variable in the Docker build command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
